### PR TITLE
Fix code scanning alert no. 3: Regular expression injection

### DIFF
--- a/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/index.js
+++ b/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/index.js
@@ -1,4 +1,5 @@
 const { Storage } = require('@google-cloud/storage');
+const _ = require('lodash');
 
 // Cloud Functions からトリガーされるメインの関数
 exports.copyFileToAnotherBucket = async (event, context, callback) => {
@@ -32,7 +33,8 @@ exports.copyFileToAnotherBucket = async (event, context, callback) => {
   }
 
   // バケット名がパターン「${projectId}-〇〇〇-if」に一致するか確認
-  if (!sourceBucketName.match(`^${projectId}-\\w*-if$`)) {
+  const safeProjectId = _.escapeRegExp(projectId);
+  if (!sourceBucketName.match(`^${safeProjectId}-\\w*-if$`)) {
     console.log(`Bucket ${sourceBucketName} does not match the pattern. Exiting.`);
     callback();
     return;

--- a/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/package.json
+++ b/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@google-cloud/storage": "^3.0.0"
+    "@google-cloud/storage": "^3.0.0",
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/es0215/til/security/code-scanning/3](https://github.com/es0215/til/security/code-scanning/3)

To fix the problem, we need to sanitize the `projectId` before embedding it into the regular expression. We can use the `_.escapeRegExp` function from the lodash library to escape any special characters in the `projectId`. This will ensure that the `projectId` cannot alter the meaning of the regular expression.

1. Import the lodash library.
2. Use the `_.escapeRegExp` function to sanitize the `projectId` before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
