### PR TITLE
Fix code scanning alert no. 2: Regular expression injection

### DIFF
--- a/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/index_v0.1.js
+++ b/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/index_v0.1.js
@@ -1,5 +1,6 @@
 // Google Cloud Storageライブラリをインポートします
 const {Storage} = require('@google-cloud/storage');
+const _ = require('lodash');
 // Storageクライアントを初期化します
 const storage = new Storage();
 // この関数は、新しいファイルがアップロードされるたびにトリガーされます
@@ -7,7 +8,7 @@ exports.copyFileToAnotherBucket = async (event, context, callback) => {
     // ファイルがアップロードされたバケットの名前を取得します
     const sourceBucketName = event.bucket;
     // 環境変数からGoogle CloudプロジェクトのIDを取得します
-    const projectId = process.env.GCLOUD_PROJECT;
+    const projectId = _.escapeRegExp(process.env.GCLOUD_PROJECT);
     // バケット名がパターン「${projectId}-〇〇〇-if」に一致するか確認します
     if (!sourceBucketName.match(`^${projectId}-\\w*-if$`)) {
         console.log(`Bucket ${sourceBucketName} does not match the pattern. Exiting.`);


### PR DESCRIPTION
Fixes [https://github.com/es0215/til/security/code-scanning/2](https://github.com/es0215/til/security/code-scanning/2)

To fix the problem, we need to sanitize the `projectId` before embedding it into the regular expression. We can use the `_.escapeRegExp` function from the lodash library to escape any special characters in the `projectId`. This will ensure that the `projectId` cannot alter the meaning of the regular expression.

1. Import the lodash library.
2. Use the `_.escapeRegExp` function to sanitize the `projectId` before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
