### PR TITLE
Fix code scanning alert no. 1: Regular expression injection

### DIFF
--- a/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/index_0.2.js
+++ b/google_cloud/cloud_functions/gcs_file_copy/node.js_v2/index_0.2.js
@@ -2,6 +2,7 @@
 const { Storage } = require('@google-cloud/storage');
 // Cloud Loggingライブラリをインポートします
 const { Logging } = require('@google-cloud/logging');
+const _ = require('lodash');
 // StorageクライアントとLoggingクライアントを初期化します
 const storage = new Storage();
 const logging = new Logging();
@@ -11,7 +12,7 @@ exports.copyFileToAnotherBucket = async (event, context) => {
     // ファイルがアップロードされたバケットの名前を取得します
     const sourceBucketName = event.bucket;
     // 環境変数からGoogle CloudプロジェクトのIDを取得します
-    const projectId = process.env.GCLOUD_PROJECT;
+    const projectId = _.escapeRegExp(process.env.GCLOUD_PROJECT);
     
     // バケット名がパターン「${projectId}-〇〇〇-if」に一致するか確認します
     if (!sourceBucketName.match(`^${projectId}-\\w*-if$`)) {


### PR DESCRIPTION
Fixes [https://github.com/es0215/til/security/code-scanning/1](https://github.com/es0215/til/security/code-scanning/1)

To fix the problem, we need to sanitize the `projectId` before embedding it into the regular expression. We can use the `_.escapeRegExp` function from the lodash library to escape any special characters in the `projectId`. This will ensure that the `projectId` cannot alter the meaning of the regular expression.

1. Install the lodash library if it is not already installed.
2. Import the lodash library in the file.
3. Use the `_.escapeRegExp` function to sanitize the `projectId` before using it in the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
