### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   terraform:
     name: 'Terraform'
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/es0215/til/security/code-scanning/4](https://github.com/es0215/til/security/code-scanning/4)

To fix the problem, you should add a `permissions:` block to the workflow job (`terraform`), minimizing GITHUB_TOKEN permissions in accordance with the least privilege principle. Since it's likely that only read access is required (especially for code checkout and read-only operations), set `contents: read` as a minimal starting point. If subsequent workflow steps (such as commenting on pull requests) fail, you may need to add `pull-requests: write` as well, but the recommended starting point is to restrict to only what's strictly necessary. Add the new `permissions:` block just under the job name (`name: 'Terraform'`) for the `terraform` job in `.github/workflows/terraform.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
