### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delete_branch.yml
+++ b/.github/workflows/delete_branch.yml
@@ -1,4 +1,6 @@
 name: delete branch action
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/es0215/til/security/code-scanning/5](https://github.com/es0215/til/security/code-scanning/5)

To fix the problem, explicitly add a `permissions:` block at either the root level of the workflow or within the relevant job (`delete_hook`). The block should grant only the required permissions for the steps performed. Since this workflow deletes branches, the minimum necessary is typically `contents: write`—read-only will not be sufficient for branch deletion (`git push origin --delete`). Insert the permissions block above the `jobs:` key for all jobs, or within the specific job if only that job needs it.

Edit `.github/workflows/delete_branch.yml`, adding the following lines after the workflow `name:` and before `on:` or above `jobs:`. For all jobs, use the workflow-level block; for a single job, nested is fine. No import or additional dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
